### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ The main reason of the fork is that the original project seam to be abadonned.
 ## Install
 
 #### Requirements
-- Windows 10 build 19041 (20H1) or later
-- Windows 11
+- Windows 11 or Windows 10 build 19041 (20H1) and later
+- Dotnet/.NET Runtime at least 6 (e.g. download latest Long Term Support Version and there either .NET Runtime or .NET Desktop Runtime 8.0.4 - the first is sufficient for this app - from this page: https://dotnet.microsoft.com/en-us/download/dotnet )
 
 ### Manual Install:
 - Unistall previous vdesk installation
@@ -39,9 +39,14 @@ Create total of 5 desktops:
 
 `vdesk create 5`
 
-Run notepad on virtual desktop 4 without switching:
+Run notepad ***o***n virtual desktop ***n***umber 4 without switching:
 
 `vdesk run -n -o 4 notepad.exe`
+
+Now the same in long syntax form instead of short:
+
+`vdesk run --no-switch --on 4 notepad.exe`
+
 
 > **Note:** If VDesk doesn't work at first, check the program's command line options for ways to create a new window - For example Chrome has the `/new-window` argument which allows it to function with VDesk.
 
@@ -57,18 +62,17 @@ To launch notepad on current desktop:
 
 `vdesk run notepad`
 
-To launch notepad on desktop 3 and open `C:\some file.txt`:
+To launch notepad on desktop 3 and open `C:\some file.txt` using it as an ***a***rgument:
 
 `vdesk run -o 3 notepad -a "C:\some file.txt"`
-
-To launch a new VirtualBox vm fullscreen on its own virtual desktop, and switch to it:
-
-`vdesk run "C:\Path to Vbox\VirtualBox.exe" -a "--comment \"VM\" --startvm \"vm-id-no\" --fullscreen"`
-> **Note:** to be tested !!
 
 To open Github in a new Chrome window on the second desktop split half screen to the left:
 
 `vdesk run -o 2 --half-split left "C:\Program Files\Google\Chrome\Application\chrome.exe" -a "/new-window https://github.com"`
+
+To launch a new Firefox using several arguments which also contain quotation marks (using `'` instead of `"` for the arguments part):
+
+`vdesk run --on 2 --no-switch "C:\Program Files\Mozilla Firefox\firefox.exe" --arguments '-P "GPT-Nutzung" -no-remote "localhost:3000"'`
 
 ## Copyright notice
 


### PR DESCRIPTION
- Added dotnet/.NET requirement
- more explicit about short and long syntax form
- explained usage for arguments containing quotation marks and deleted old (wrong?) example - for the firefox example `\"` didn't work for me

Thank you for your maintaining :-).

P.S. About that part named on the bottom, i interpreted this as `--fullscreen` was part of the arguments for the VirtualBox.exe and should show how to use several arguements also containing qutotation marks. It didn't work for me (`vdesk run --on 2 --no-switch "C:\Program Files\Mozilla Firefox\firefox.exe" --arguments "-P \"GPT-Nutzung\" -no-remote \"localhost:3000\""`). So i deleted it and added a working command line usage. If I missinterpreted feel free to change.


Part:
To launch a new VirtualBox vm fullscreen on its own virtual desktop, and switch to it:

`vdesk run "C:\Path to Vbox\VirtualBox.exe" -a "--comment \"VM\" --startvm \"vm-id-no\" --fullscreen"`
> **Note:** to be tested !!